### PR TITLE
Fix calibration import and S3 upload args

### DIFF
--- a/RP5/basic_pipelines/calibration.py
+++ b/RP5/basic_pipelines/calibration.py
@@ -1,6 +1,7 @@
 import os
 import datetime
 import threading
+import time
 import cv2
 # --------------------------------------------
 # Periodic Calibration Upload

--- a/RP5/basic_pipelines/dataCapture.py
+++ b/RP5/basic_pipelines/dataCapture.py
@@ -83,7 +83,7 @@ def save_clip_and_metadata(frames_data, s3_client, OUTPUT_BASE_DIR, TIGRIS_BUCKE
     for fn in (vid, meta_fn, best_clean, best_ann):
         lp = os.path.join(out_dir, fn)
         key = f"{date_str}/{fn}"
-        upload(lp, s3_client, TIGRIS_BUCKET_NAME, key)
+        upload(lp, fn, s3_client, TIGRIS_BUCKET_NAME, key)
 
 
 


### PR DESCRIPTION
## Summary
- add missing `time` import for calibration frame uploads
- pass file name to `upload()` when saving clips

## Testing
- `python -m py_compile pothole/stream.py basic_pipelines/detect.py basic_pipelines/dataCapture.py basic_pipelines/gps.py pothole/gps.py basic_pipelines/calibration.py`
- `pytest --collect-only`

------
https://chatgpt.com/codex/tasks/task_e_684045abd7008327b1ed7a54a79caea6