### PR TITLE
Add missing package requirements

### DIFF
--- a/RP5/requirements.txt
+++ b/RP5/requirements.txt
@@ -3,3 +3,7 @@ setproctitle
 opencv-python
 loguru
 boto3
+requests
+pynmea2
+pyserial
+PyGObject


### PR DESCRIPTION
## Summary
- add extra Python packages used by pothole scripts to requirements
- attempt to install dependencies in a clean virtualenv

## Testing
- `pip install -r RP5/requirements.txt` *(fails: Dependency 'girepository-2.0' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840488531d48327b4f3041a68ab4517